### PR TITLE
Add participant email

### DIFF
--- a/toolkit/api/tests/endpoints/participant.py
+++ b/toolkit/api/tests/endpoints/participant.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.dispatch import Signal, receiver
 
-from toolkit.apps.matter.signals import MATTER_ADD_PARTICIPANT
+from toolkit.apps.matter.signals import PARTICIPANT_ADDED
 from toolkit.apps.workspace.models import Workspace
 
 from . import BaseEndpointTest
@@ -65,8 +65,8 @@ class MatterParticipantTest(BaseEndpointTest):
         """
         self.client.login(username=self.lawyer.username, password=self.password)
 
-        @receiver(MATTER_ADD_PARTICIPANT)
-        def f(matter, user, **kwargs):
+        @receiver(PARTICIPANT_ADDED)
+        def f(matter, participant, user, **kwargs):
             self.signal_called = True
 
         #

--- a/toolkit/api/views/participant.py
+++ b/toolkit/api/views/participant.py
@@ -12,7 +12,7 @@ from rest_framework import exceptions
 from rest_framework.response import Response
 from rest_framework import status as http_status
 
-from toolkit.apps.matter.signals import MATTER_ADD_PARTICIPANT
+from toolkit.apps.matter.signals import PARTICIPANT_ADDED
 from toolkit.apps.workspace.models import Workspace
 from toolkit.apps.workspace.services import EnsureCustomerService
 
@@ -66,7 +66,7 @@ class MatterParticipant(generics.CreateAPIView,
 
         if new_participant not in self.matter.participants.all():
             self.matter.participants.add(new_participant)
-            MATTER_ADD_PARTICIPANT.send(sender=self, matter=self.matter, user=new_participant)
+            PARTICIPANT_ADDED.send(sender=self, matter=self.matter, participant=new_participant, user=request.user)
 
         return Response(status=http_status.HTTP_202_ACCEPTED)
 

--- a/toolkit/apps/matter/mailers.py
+++ b/toolkit/apps/matter/mailers.py
@@ -1,0 +1,5 @@
+from toolkit.mailers import BaseSpecifiedFromMailerService
+
+
+class ParticipantAddedEmail(BaseSpecifiedFromMailerService):
+    email_template = 'participant_added'

--- a/toolkit/apps/matter/signals.py
+++ b/toolkit/apps/matter/signals.py
@@ -1,4 +1,16 @@
-from django.dispatch import Signal
+from django.dispatch import Signal, receiver
+
+from .mailers import ParticipantAddedEmail
 
 
-MATTER_ADD_PARTICIPANT = Signal(providing_args=['matter', 'user'])
+PARTICIPANT_ADDED = Signal(providing_args=['matter', 'participant', 'user'])
+
+
+@receiver(PARTICIPANT_ADDED)
+def participant_added(sender, matter, participant, user, **kwargs):
+    recipient = (participant.get_full_name(), participant.email)
+
+    from_tuple = (user.get_full_name(), user.email)
+
+    mailer = ParticipantAddedEmail(from_tuple=from_tuple, recipients=(recipient,))
+    mailer.process(custom_message=False, matter=matter, user=user)

--- a/toolkit/apps/matter/templates/email/participant_added.email
+++ b/toolkit/apps/matter/templates/email/participant_added.email
@@ -1,0 +1,24 @@
+{% extends 'email/base.email' %}
+
+{% block subject_line %}You have been invited to the {{ matter.name }} matter on LawPal{% endblock %}
+
+{% block html_content %}
+    <p>{{ user.get_full_name }} invited you to a matter:</p>
+    {% if matter.description %}
+        <h2 style="margin-bottom: 0;"><strong>{{ matter.name }}</strong></h2>
+        <p style="margin-top: 5px;">Description of the matter</p>
+    {% else %}
+        <h2><strong>{{ matter.name }}</strong></h2>
+    {% endif %}
+
+    {% if custom_message %}
+        <p>{{ custom_message }}</p>
+    {% else %}
+        <p>What's LawPal? It's the easiest way for clients and lawyers to interact. <a href="https://lawpal.com/" target="_blank">Learn more »</a></p>
+    {% endif %}
+
+    <h2><a href="#" target="_blank">Accept this invitation to get started</a></h2>
+
+    <h4 style="margin-bottom: 0;"><b>Questions?</b></h4>
+    <p style="margin-top: 5px;">Contact Joe Bloggs at <a href="mailto:sogobloggs@gmail.com" target="_blank">sogobloggs@gmail.com</a>.</p>
+{% endblock %}

--- a/toolkit/apps/matter/tests/__init__.py
+++ b/toolkit/apps/matter/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 from .validate_settings import *
 from .forms import *
+from .signals import *
 from .views import *

--- a/toolkit/apps/matter/tests/signals.py
+++ b/toolkit/apps/matter/tests/signals.py
@@ -1,0 +1,33 @@
+from django.core import mail
+from django.test import TestCase
+
+from model_mommy import mommy
+
+from toolkit.casper.workflow_case import BaseScenarios
+
+from ..signals import participant_added
+
+
+class ParticipantAddedTest(BaseScenarios, TestCase):
+    def setUp(self):
+        super(ParticipantAddedTest, self).setUp()
+        self.basic_workspace()
+
+    def test_sends_email_to_added_participant(self):
+        participant = mommy.make('auth.User', first_name='New', last_name='Participant', email='test+participant@lawpal.com')
+
+        # No email has been sent yet
+        self.assertEqual(0, len(mail.outbox))
+
+        # Check the email was sent
+        participant_added(self, self.matter, participant, self.lawyer)
+        self.assertEqual(len(mail.outbox), 1)
+
+        # Test parts of the email
+        email = mail.outbox[0]
+        self.assertEqual(email.subject, 'You have been invited to the Lawpal (test) matter on LawPal')
+        self.assertEqual(len(email.to), 1)
+        self.assertEqual(email.to, ['test+participant@lawpal.com'])
+        self.assertEqual(email.from_email, u'Lawyer Test (via LawPal) support@lawpal.com')
+        self.assertEqual(email.extra_headers, {'Reply-To': self.lawyer.email})
+


### PR DESCRIPTION
The participants endpoints in the API will now call a signal when a new participant is added. The code now listens on that signal and sends an email to the participant telling them they've been invited.

The next stage will be some custom message for the participant from the lawyer, and the invite URL that's generated.
