### PR TITLE
Moved css reference to pe-icon css into HTML so that the font ref  is not lost

### DIFF
--- a/gui/config.html
+++ b/gui/config.html
@@ -7,6 +7,7 @@
 
   <!-- App LESS -->
   <link href="<!-- @echo staticBase -->ng/css/app.less" type="text/css" rel="stylesheet/less">
+  <link href="/static/fonts/pe-icon-7-stroke/css/pe-icon-7-stroke.css" rel="stylesheet" data-remove="exclude" />
   <script src="<!-- @echo staticBase -->ng/bower_components/jquery/jquery.js" data-remove="exclude"></script>
   <script src="<!-- @echo staticBase -->ng/bower_components/jquery-ui/ui/jquery-ui.js" data-remove="exclude"></script>
   <script src="<!-- @echo staticBase -->ng/bower_components/bootstrap/dist/js/bootstrap.js" data-remove="exclude"></script>

--- a/gui/css/app.less
+++ b/gui/css/app.less
@@ -6,7 +6,7 @@
 @import "./flat-ui.less";
 @import "./application.less";
 @import "./animate.less";
-@import "../../fonts/pe-icon-7-stroke/css/pe-icon-7-stroke.css";
+/*@import "../../fonts/pe-icon-7-stroke/css/pe-icon-7-stroke.css";*/
 
 
 /* Directive LESS */


### PR DESCRIPTION
@rosscdh  you you please check this fix is going to work in a production build
