### PR TITLE
[REVIEW] fix/position-delete-revision-button

### DIFF
--- a/gui/partial/checklist/includes/itemdetails.html
+++ b/gui/partial/checklist/includes/itemdetails.html
@@ -143,7 +143,6 @@
             <div class="doc-wrap">
                 <!-- <span class="version">{{ data.selectedItem.latest_revision.slug }}</span> -->
                 <h4><a href="javascript:;" ng-click="showRevisionDocument(data.selectedItem.latest_revision)"><span class="fui-document status-{{ data.selectedItem.latest_revision.status }}"></span> {{ data.selectedItem.latest_revision.name }}</a></h4>
-                <span class="close" ng-click="deleteLatestRevision()">x</span>
                 <div class="desc" ng-hide="data.showEditRevisionDescriptionForm||data.usdata.current.user_class!=='lawyer'">
                      <a href="javascript:;" class="link"
                         ng-click="data.showEditRevisionDescriptionForm=!data.showEditRevisionDescriptionForm;data.editRevisionDescription=data.selectedItem.latest_revision.description;focus('eventEditLatestRevisionDescription')">
@@ -162,6 +161,7 @@
                     <a href="javascript:;" class="btn btn-link btn-xs" ng-click="showRevisionDocument(data.selectedItem.latest_revision)">View</a>  <a href="{{ data.selectedItem.latest_revision.user_download_url }}" class="btn btn-link btn-xs" target="_blank">Download</a>
                     <a href="javascript:;" class="btn btn-link btn-xs" ng-click="requestReview(data.selectedItem.latest_revision)">Request Review</a>
 <!--                     <a href="javascript:;" class="btn btn-link btn-xs" ng-click="requestSigning(data.selectedItem.latest_revision)">Request Signing</a> -->
+                    <a href="javascript:;" class="btn btn-link btn-xs" ng-click="deleteLatestRevision()">Delete</a>
                     <div class="btn-group pull-right">
                         <button type="button" class="btn btn-default btn-xs status-{{ data.selectedItem.latest_revision.status }}" data-toggle="dropdown">
                           {{ data.matter._meta.revision.status | valueforkey:data.selectedItem.latest_revision.status }}


### PR DESCRIPTION
Changed the position of the delete revision button to the bottom bar of the latest revision.

@alexhalliday and @rosscdh please review and merge
