### PR TITLE
Make tempate ache paths and refence to cache paths match

### DIFF
--- a/gui/Gruntfile.js
+++ b/gui/Gruntfile.js
@@ -140,10 +140,17 @@ module.exports = function (grunt) {
       template_paths: {
         src: ['temp/templates.js'],
         overwrite: true,                 // overwrite matched source files
-        replacements: [{
+        replacements: [
+        /*
+          {
           from: 'partial/',
-          to: '<%= PRODUCTION_PATH %>' + 'partial/'
-        }]
+          to: '<%= APP_STATIC_PATH %>' + 'partial/'
+          },*/
+          {
+          from: '$templateCache.put(\'partial/',
+          to: '$templateCache.put(\'<%= APP_STATIC_PATH %>partial/'
+          }
+        ]
       }
     },
     copy: {


### PR DESCRIPTION
@rosscdh I have attempted to ensure that the HTML template cache references for all HTML files are the same as when these templates are references. When interrogating the built files all looks good, however I need you to show me how to test it as a production site.
