### PR TITLE
[REVIEW] enabeld use of pipelinecachestorage

### DIFF
--- a/toolkit/settings.py
+++ b/toolkit/settings.py
@@ -53,8 +53,8 @@ STATICFILES_DIRS = (
     ("ng", os.path.join(SITE_ROOT, 'gui', 'dist')),
 )
 
-#STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
-STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
+STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+#STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 
 MEDIA_ROOT = os.path.join(SITE_ROOT, 'media')
 MEDIA_URL = '/m/'


### PR DESCRIPTION
To test.

local_settings.py

```
DEBUG = False
TEST_PREPROD = True
```

then

```
./manage.py collectstatic --noinput
```

and it should compile easily; you will see in the collectstatic output that the css refers to some weird stuff including a pdf file. Would appreciate some feedback on cleaning this up?
