### PR TITLE
[WIP]Feature/comments

### DIFF
--- a/gui/css/modules/checklist.less
+++ b/gui/css/modules/checklist.less
@@ -619,6 +619,7 @@ html,body, div.full
 		}
 
 		.global {
+			opacity: 0.6;
 			background-color: #5ccb6a;
 			.iconbar-unread{
 			// background-color: #444444;

--- a/gui/partial/checklist/checklist.less
+++ b/gui/partial/checklist/checklist.less
@@ -213,7 +213,7 @@ tr.item-heading.file-drag-over td:nth-child(2):before {
 }
 
 .checklist-wrapper .checklist-col {
-	padding-bottom: 0.5em;
+	padding-bottom: 0em;
 }
 
 /*

--- a/gui/partial/checklist/includes/itemchat.html
+++ b/gui/partial/checklist/includes/itemchat.html
@@ -13,7 +13,7 @@
 
     <div class="col-xs-12 comment-wrapper colleague">
            <div class="comment-explanation">Discuss with your <span class="expl-emphasis">Colleagues</span></div>
-        <textarea class="form-control" rows="2" placeholder="Write a comment for your colleague and hit 'Enter'" ng-model="data.selectedItem.newcomment" required></textarea>
+        <textarea class="form-control" rows="2" placeholder="Write a comment and hit 'Enter'" ng-model="data.selectedItem.newcomment" required></textarea>
 
 
      <!--Fill comment-explanation with :


### PR DESCRIPTION
This branch implements internal/global comments per Item, or at least provides the visual space for where the per-item global and internal comments should be implemented. 
![screen shot 2014-05-27 at 10 32 04 am](https://cloud.githubusercontent.com/assets/3011773/3095231/21a29476-e5c5-11e3-9140-8a39a45d61cd.png)

The comment box now lives in the right upper corner of the checklist view. Internal comments can be left in the blue box, while clicking on the green tab should change the styling around the text box to look like a 'global' comment. 

![screen shot 2014-05-27 at 10 36 11 am](https://cloud.githubusercontent.com/assets/3011773/3095249/6ff3e5d0-e5c5-11e3-9128-2dd2172ab19c.png)

Comments should appear in the container right underneath, and the overall column minimizes the per Item/All Activity column, as this is no longer the best way to keep up to date on what is going on in the matter. 

CSS classes are provided and should be changed based on conditionals of:
1. Who is accessing this? (A client should not have access to the internal chat. Therefore, they will only see a green chat box and the subsequent comment feed underneath)
2. All comments should look like how comments look right now. 
