### PR TITLE
2 lines of css to the rescue

### DIFF
--- a/toolkit/apps/default/static/css/application.css
+++ b/toolkit/apps/default/static/css/application.css
@@ -820,7 +820,7 @@ body.gui .main-content {
   border-bottom: 2px solid #dadada;
   margin-bottom: 20px;
   position: relative;
-  max-height: 221px;
+  height: 221px;
 }
 .matter .card .export-button {
   transform: rotate(90deg);
@@ -857,7 +857,7 @@ body.gui .main-content {
   font-size: 12px;
   line-height: 1.2;
   margin: 0;
-  height: 40px;
+  height: 30px;
   padding: 3px;
   position: absolute;
   top: 18px;

--- a/toolkit/apps/default/static/less/application.less
+++ b/toolkit/apps/default/static/less/application.less
@@ -179,7 +179,7 @@ body.gui {
   border-bottom: 2px solid mix(@brand-primary, white, 20);
   margin-bottom: 20px;
   position: relative;
-  max-height: 221px;
+  height: 221px;
 
 
   .download-link{
@@ -223,7 +223,7 @@ body.gui {
     //font-style: italic;
     line-height: 1.2;
     margin: 0;
-    height: 40px;
+    height: 30px;
     padding: 3px;
     position: absolute;
     top: 18px;


### PR DESCRIPTION
Changes max-height to just height to make all matter cards even all the time.
Changes the height of export-message p so there is no way it will ever overlap the text underneath. 

![screen shot 2014-05-28 at 9 55 19 am](https://cloud.githubusercontent.com/assets/3011773/3107757/e8264412-e688-11e3-962e-15f9fb4191eb.png)
