### PR TITLE
[REVIEW] Crocodoc speed

### DIFF
--- a/toolkit/apps/review/services.py
+++ b/toolkit/apps/review/services.py
@@ -76,12 +76,6 @@ class CrocodocLoaderService(object):
             self.service.generate()
 
     def process(self):
-        # if this is a brand new file, we now need to ensure its available lcoally
-        # and then if/when it is upload it to crocdoc
-        self.ensure_local_file()
-
-        
-
         # @TODO this should ideally be set in the service on init
         # and session automatically updated
         # https://crocodoc.com/docs/api/ for more info
@@ -103,10 +97,6 @@ class CrocodocLoaderService(object):
                 #
                 #"filter": self.get_filter_ids() # must be a comma seperated list
         }
-        #
-        # Set out session key based on params above
-        #
-        self.service.obj.crocodoc_service.session_key(**CROCODOC_PARAMS),
 
         return {
             'crocodoc': self.service.obj.crocodoc_service,

--- a/toolkit/apps/review/tasks.py
+++ b/toolkit/apps/review/tasks.py
@@ -19,9 +19,13 @@ def crocodoc_upload_task(user, revision):
     #
     for reviewdocument in revision.reviewdocument_set.all():
         logger.info('Upload of document for review %s for %s' % (revision, user))
+        # get service
         async_uploader_service = CrocodocLoaderService(user=user, reviewdocument=reviewdocument)
-
+        # ensure the file is available locally
+        async_uploader_service.ensure_local_file()
+        # get the file 
         crocodoc_view_url = async_uploader_service.process().get('crocodoc_view_url', None)
+
         if crocodoc_view_url is not None:
             r = requests.get(crocodoc_view_url)
             if r.status_code in [200]:


### PR DESCRIPTION
I've done a preliminary investigation; and made a few small changes. (shaved 1.2 secs). the downside is that it appears to work perfectly but i have a gut feeling may cause issues due to the removal of the session check which is where the 1.2 was saved (I've tested it with new sessions in new browsers and it appears fine).

But from what I can see the speed problem seems to be the initial communication with crocodoc via REST (no the document does not get uploaded again) take a look and see if this helps (
