### PR TITLE
[REVIEW]Fix/item review sign

### DIFF
--- a/gui/css/application.less
+++ b/gui/css/application.less
@@ -701,15 +701,17 @@
 
 
 .signing-setup-link{
-  font-weight: normal;
+  font-weight: bold;
   position: relative;
   padding-bottom: 3px;
   font-size: 12px;
   width: 240px;
+  margin-top: 5px;
+  margin-left: 16px;
   display: block;
   text-decoration: underline;
    div:last-child{
-    margin-left: 10px;
+    margin-left: 8px;
   }
 }
 

--- a/gui/partial/checklist/includes/itemdetails.html
+++ b/gui/partial/checklist/includes/itemdetails.html
@@ -233,8 +233,8 @@
                     Cancel Signing
                 </a>
 
-                <div ng-hide="data.selectedItem.latest_revision.signing.is_claimed">
-                 <a class="signing-setup-link" href="javascript:;" ng-click="showSigning(data.selectedItem.latest_revision, null)" style="margin-top:7px; margin-left:14px;"><div class="notice-me animated-slow pulse"><i class="fa fa-exclamation-circle"></i></div>
+                <div ng-hide="data.selectedItem.latest_revision.signing.is_claimed" class="">
+                 <a class="signing-setup-link" href="javascript:;" ng-click="showSigning(data.selectedItem.latest_revision, null)"><div class="notice-me animated-slow shake"><i class="fa fa-exclamation-circle"></i></div>
                     <div>Please set up the document for signing</div></a>
                 </div>
 


### PR DESCRIPTION
This pull request changes the look of the area that happens after a colleague/Matter Owner requests a document to be signed. Takes out the button and replaces with explanatory-text heavy link:

![screen shot 2014-06-16 at 1 03 09 pm](https://cloud.githubusercontent.com/assets/3011773/3292595/520e8d78-f591-11e3-81b2-2d32514656d9.png)
