### PR TITLE
[REVIEW] Catch invalid review.url

### DIFF
--- a/gui/service/matterItem.js
+++ b/gui/service/matterItem.js
@@ -767,7 +767,7 @@ angular.module('toolkit-gui')
 					// Invalid url provided
 					$timeout( function(){
 						deferred.reject( new Error('Unable to update revision') );
-					}, 1)
+					}, 1);
 				}
 
 				return deferred.promise;


### PR DESCRIPTION
Added catch for null/undefined review.url value
Line 749 of matterItem.js
